### PR TITLE
add WAO

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ We will classify development technical documentation resources in the following 
 - [VS Code AO](https://cookbook_ao.g8way.io/references/editor-setup.html) - Plugins and configurations for AO development in VS Code
 - [BetterIDEa](https://ide.betteridea.dev/) - Web-based Code editor with native AO integrations
 - [Protocol.Land](https://github.com/labscommunity/protocol-land) - Git hosting and Github mirroring on Arweave
-    
+- [WAO](https://github.com/weavedb/wao) - In-memory AO testing framework
+
 ### Oracles/Bridges
 
 - [0rbit](https://docs.0rbit.co/) - Oracle for retrieving Web2 data into AO


### PR DESCRIPTION
I recently created an in-memory testing framework called [WAO](https://github.com/weavedb/wao) to accelerate AO process testing and added it under `Coding tools`.

This framework emulates the Arweave blockchain and the AO units (MU/SU/CU) in memory, making AO process integration tests 1000x faster than testing on mainnet in many cases, which is a major missing tool in the AO ecosystem.

It also includes an aoconnect SDK wrapper that provides syntactic sugar, making AO interacting code more concise and improving developer productivity.

It's been used internally at WeaveDB for various products and is in a stable state now.